### PR TITLE
Update lua-circuit-breaker-ngx-usage.lua

### DIFF
--- a/ngx_lua_sample/lua-circuit-breaker-ngx-usage.lua
+++ b/ngx_lua_sample/lua-circuit-breaker-ngx-usage.lua
@@ -12,7 +12,7 @@ local settings = {
     wait_duration_in_half_open_state= 120,
     half_open_max_calls_in_window= 5,
     half_open_min_calls_in_window= 2,
-    notify = function(name, state)
+    notify = function(state, name)
       ngx.log(ngx.ERR,string.format("Breaker [ %s ] state changed to [ %s ]", name, state))
     end,
 }

--- a/ngx_lua_sample/lua-circuit-breaker-ngx-usage.lua
+++ b/ngx_lua_sample/lua-circuit-breaker-ngx-usage.lua
@@ -13,7 +13,7 @@ local settings = {
     half_open_max_calls_in_window= 5,
     half_open_min_calls_in_window= 2,
     notify = function(state, name)
-      ngx.log(ngx.ERR,string.format("Breaker [ %s ] state changed to [ %s ]", name, state))
+      ngx.log(ngx.ERR,string.format("Breaker [ %s ] state changed to [ %s ]", name, state._state))
     end,
 }
 


### PR DESCRIPTION
### Summary
Changed variables order
```
nginx_1  | 2023/10/23 12:06:42 [error] 7#7: *83 [lua] lua-circuit-breaker-ngx-usage.lua:16: _notify(): Breaker [ table: 0x7fe5ea1aac88 ] state changed to [ my_cb ], client: 192.168.144.1, server: , request: "GET /lua_content HTTP/1.1", host: "localhost:8080"
```

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX